### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -1,5 +1,8 @@
 name: Rust
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: [ "master" ]


### PR DESCRIPTION
Potential fix for [https://github.com/kaden126/bux2/security/code-scanning/1](https://github.com/kaden126/bux2/security/code-scanning/1)

In general, to fix this issue you should explicitly declare a `permissions` block in the workflow (either at the root or for each job) that grants only the scopes required. For this Rust CI workflow, the steps only need to read the repository contents to build and test the code; they do not need to write to the repo or interact with issues/PRs. Therefore, setting `contents: read` at the workflow level is sufficient and preserves existing functionality.

The single best fix here is to add a top-level `permissions` key right after the `name` (or before `jobs`) in `.github/workflows/rust.yml`, with `contents: read`. This will apply to all jobs that do not specify their own permissions (in this file there is only `build`). No changes to steps or additional methods/imports are needed. Concretely, insert:

```yaml
permissions:
  contents: read
```

after line 2 (the blank line following the `name: Rust` line), keeping indentation consistent with other top-level keys (`on`, `env`, `jobs`).


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
